### PR TITLE
feat(idl): add IDL parsing and Phase 1 project structure

### DIFF
--- a/accounts/doc.go
+++ b/accounts/doc.go
@@ -1,0 +1,2 @@
+// Package accounts provides account types, encoding, and discriminators for Anchor.
+package accounts

--- a/client/doc.go
+++ b/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides the Anchor program client and instruction builder.
+package client

--- a/cmd/go-anchor/doc.go
+++ b/cmd/go-anchor/doc.go
@@ -1,0 +1,2 @@
+// Package main is the go-anchor CLI.
+package main

--- a/cmd/go-anchor/main.go
+++ b/cmd/go-anchor/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go-anchor <command> [args...]")
+		fmt.Fprintln(os.Stderr, "Commands: idl (fetch, validate, convert)")
+		os.Exit(1)
+	}
+	// TODO: implement idl fetch, validate, convert
+	fmt.Printf("go-anchor %s (not yet implemented)\n", os.Args[1])
+}

--- a/cpi/doc.go
+++ b/cpi/doc.go
@@ -1,0 +1,2 @@
+// Package cpi provides CPI (cross-program invocation) context and helpers.
+package cpi

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors provides error code mapping for Anchor programs.
+package errors

--- a/events/doc.go
+++ b/events/doc.go
@@ -1,0 +1,2 @@
+// Package events provides event encoding and parsing.
+package events

--- a/idl/idl.go
+++ b/idl/idl.go
@@ -1,0 +1,147 @@
+// Package idl provides parsing and types for Anchor IDL (Interface Description Language).
+package idl
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// IDL is the root structure for an Anchor program's interface (v0.30+ spec).
+type IDL struct {
+	Address      string            `json:"address"`
+	Metadata     Metadata          `json:"metadata"`
+	Instructions []Instruction     `json:"instructions"`
+	Accounts     []Account         `json:"accounts"`
+	Types        []TypeDef         `json:"types,omitempty"`
+	Events       []Event           `json:"events,omitempty"`
+	Errors       []ErrorCode       `json:"errors,omitempty"`
+	Constants    []Constant        `json:"constants,omitempty"`
+	Docs         []string          `json:"docs,omitempty"`
+}
+
+// Metadata holds program metadata.
+type Metadata struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Spec    string `json:"spec"`
+}
+
+// Instruction describes a callable instruction.
+type Instruction struct {
+	Name          string                `json:"name"`
+	Discriminator Discriminator         `json:"discriminator"`
+	Accounts      []InstructionAccount  `json:"accounts"`
+	Args          []Field               `json:"args"`
+	Docs          []string              `json:"docs,omitempty"`
+}
+
+// InstructionAccount describes an account required by an instruction.
+type InstructionAccount struct {
+	Name     string `json:"name"`
+	Writable bool   `json:"writable,omitempty"`
+	Signer   bool   `json:"signer,omitempty"`
+	Optional bool   `json:"optional,omitempty"`
+}
+
+// Account describes a custom account type.
+type Account struct {
+	Name          string        `json:"name"`
+	Discriminator Discriminator `json:"discriminator"`
+	Docs          []string      `json:"docs,omitempty"`
+}
+
+// TypeDef describes a type (struct, enum, etc.).
+type TypeDef struct {
+	Name string    `json:"name"`
+	Type TypeDefTy `json:"type"`
+	Docs []string  `json:"docs,omitempty"`
+}
+
+// TypeDefTy is the type definition body.
+type TypeDefTy struct {
+	Kind      string         `json:"kind"`
+	Fields    []Field        `json:"fields,omitempty"`
+	Variants  []EnumVariant  `json:"variants,omitempty"`
+	Alias     *string        `json:"alias,omitempty"`
+}
+
+// Field describes a struct field or instruction arg.
+type Field struct {
+	Name string      `json:"name"`
+	Type interface{} `json:"type"`
+	Docs []string    `json:"docs,omitempty"`
+}
+
+// EnumVariant describes an enum variant.
+type EnumVariant struct {
+	Name   string  `json:"name"`
+	Fields []Field `json:"fields,omitempty"`
+}
+
+// Event describes an emit event.
+type Event struct {
+	Name          string        `json:"name"`
+	Discriminator Discriminator `json:"discriminator"`
+	Fields        []Field       `json:"fields,omitempty"`
+	Docs          []string      `json:"docs,omitempty"`
+}
+
+// ErrorCode describes a program error.
+type ErrorCode struct {
+	Code uint64   `json:"code"`
+	Name string   `json:"name"`
+	Msg  string   `json:"msg,omitempty"`
+	Docs []string `json:"docs,omitempty"`
+}
+
+// Constant describes a program constant.
+type Constant struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// Discriminator is an 8-byte instruction/account/event selector.
+type Discriminator [8]byte
+
+// UnmarshalJSON implements json.Unmarshaler for Discriminator.
+func (d *Discriminator) UnmarshalJSON(data []byte) error {
+	var raw []json.Number
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 8 {
+		return errors.New("discriminator must be 8 bytes")
+	}
+	for i := 0; i < 8; i++ {
+		n, err := raw[i].Int64()
+		if err != nil || n < 0 || n > 255 {
+			return errors.New("discriminator bytes must be 0-255")
+		}
+		d[i] = byte(n)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for Discriminator.
+func (d Discriminator) MarshalJSON() ([]byte, error) {
+	arr := make([]int, 8)
+	for i := 0; i < 8; i++ {
+		arr[i] = int(d[i])
+	}
+	return json.Marshal(arr)
+}
+
+// Bytes returns the discriminator as a slice.
+func (d Discriminator) Bytes() []byte {
+	return d[:]
+}
+
+// Parse unmarshals IDL from JSON bytes.
+func Parse(data []byte) (*IDL, error) {
+	var idl IDL
+	if err := json.Unmarshal(data, &idl); err != nil {
+		return nil, err
+	}
+	return &idl, nil
+}

--- a/idl/parse_test.go
+++ b/idl/parse_test.go
@@ -1,0 +1,89 @@
+package idl
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	raw := `{
+		"address": "6khKp4BeJpCjBY1Eh39ybiqbfRnrn2UzWeUARjQLXYRC",
+		"metadata": {
+			"name": "counter",
+			"version": "0.1.0",
+			"spec": "0.1.0"
+		},
+		"instructions": [
+			{
+				"name": "increment",
+				"discriminator": [11, 18, 104, 9, 104, 174, 59, 33],
+				"accounts": [{"name": "counter", "writable": true}],
+				"args": []
+			}
+		],
+		"accounts": [
+			{
+				"name": "Counter",
+				"discriminator": [255, 176, 4, 245, 188, 253, 124, 25]
+			}
+		],
+		"types": [
+			{
+				"name": "Counter",
+				"type": {
+					"kind": "struct",
+					"fields": [{"name": "count", "type": "u64"}]
+				}
+			}
+		]
+	}`
+
+	idl, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if idl.Address != "6khKp4BeJpCjBY1Eh39ybiqbfRnrn2UzWeUARjQLXYRC" {
+		t.Errorf("unexpected address: %s", idl.Address)
+	}
+	if idl.Metadata.Name != "counter" {
+		t.Errorf("unexpected metadata name: %s", idl.Metadata.Name)
+	}
+	if len(idl.Instructions) != 1 {
+		t.Fatalf("expected 1 instruction, got %d", len(idl.Instructions))
+	}
+	if idl.Instructions[0].Name != "increment" {
+		t.Errorf("unexpected instruction name: %s", idl.Instructions[0].Name)
+	}
+	if idl.Instructions[0].Discriminator[0] != 11 {
+		t.Errorf("unexpected discriminator[0]: %d", idl.Instructions[0].Discriminator[0])
+	}
+	if len(idl.Accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(idl.Accounts))
+	}
+	if idl.Accounts[0].Name != "Counter" {
+		t.Errorf("unexpected account name: %s", idl.Accounts[0].Name)
+	}
+	if len(idl.Types) != 1 {
+		t.Fatalf("expected 1 type, got %d", len(idl.Types))
+	}
+	if idl.Types[0].Name != "Counter" {
+		t.Errorf("unexpected type name: %s", idl.Types[0].Name)
+	}
+}
+
+func TestDiscriminatorRoundTrip(t *testing.T) {
+	d := Discriminator{11, 18, 104, 9, 104, 174, 59, 33}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var d2 Discriminator
+	if err := json.Unmarshal(data, &d2); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		if d[i] != d2[i] {
+			t.Errorf("byte %d: got %d, want %d", i, d2[i], d[i])
+		}
+	}
+}


### PR DESCRIPTION
Phase 1 Foundation:
- idl package: Parse Anchor v0.30+ IDL JSON, Discriminator type, Instruction/Account/TypeDef/Event/ErrorCode structs
- Project structure: accounts, client, cpi, events, errors packages; cmd/go-anchor CLI stub
- Tests for IDL parse and discriminator round-trip