### PR TITLE
chore(rules): add Go layout and unit test rules

### DIFF
--- a/.cursor/rules/go-project-standards.mdc
+++ b/.cursor/rules/go-project-standards.mdc
@@ -1,0 +1,24 @@
+---
+description: Follow Go project layout and add unit tests for important features
+globs: **/*.go
+alwaysApply: false
+---
+
+# Go Project Standards
+
+## Project Layout
+
+Follow standard [Go project layout](https://github.com/golang-standards/project-layout):
+
+- `/cmd/` — main applications (e.g. `cmd/go-anchor/`)
+- `/idl/`, `/client/`, `/accounts/`, etc. — library packages
+- `/internal/` — private packages (not importable by others)
+- `/pkg/` — reusable library code (optional)
+- `*_test.go` — tests colocated with source
+
+## Unit Tests
+
+- Add unit tests for **important features** (IDL parsing, encoding, discriminators, PDA derivation, etc.)
+- Test files: `*_test.go` in the same package
+- Use table-driven tests where appropriate
+- Aim for coverage of critical paths and edge cases

--- a/.cursor/rules/pre-push-workflow.mdc
+++ b/.cursor/rules/pre-push-workflow.mdc
@@ -61,7 +61,7 @@ Before pushing, ensure commits are well-structured:
 - **Split into small commits** — each commit should be easy to review
 - **One logical change per commit** — a finished feature, fix, or refactor
 - **Atomic commits** — each commit should be complete and self-contained; the repo should build and tests should pass after any commit
-- **Clear messages** — use imperative mood (e.g. `Add IDL parser`, `Fix discriminator hasinging`)
+- **Clear messages** — use imperative mood (e.g. `Add IDL parser`, `Fix discriminator hashing`)
 
 ### ✅ Good
 ```


### PR DESCRIPTION
Add go-project-standards.mdc: follow Go project layout (/cmd, /idl, /internal, etc.); add unit tests for important features. Fix typo in pre-push-workflow (hasinging → hashing).